### PR TITLE
Changing 智普AI to 智谱AI 

### DIFF
--- a/video-generation.md
+++ b/video-generation.md
@@ -75,7 +75,7 @@ A reading list of video generation
 
 * **vivago.ai**[[Page](https://vivago.ai/video)]
 
-* **智普AI**[[Page](https://chatglm.cn/video)]
+* **智谱AI**[[Page](https://chatglm.cn/video)]
 
 ### Translation 
 * **Goenhance.ai**[[Page](https://www.goenhance.ai/)]


### PR DESCRIPTION
Dear author, thank you for your great work on maintaining this paper list. 

I would like to point out that the correct name of Zhipu AI in Chinese should be 智谱AI.

So this PR is to correct this name usage. 

Thank you. 